### PR TITLE
fix: Fix new Google users stranded when OAuth starts from sign-in

### DIFF
--- a/apps/console/src/app/(auth)/auth/callback/route.test.ts
+++ b/apps/console/src/app/(auth)/auth/callback/route.test.ts
@@ -162,17 +162,19 @@ describe("auth callback", () => {
     expect(mockConsumeGoogleSignupProof).not.toHaveBeenCalled()
   })
 
-  it("blocks a first-time Google user without a valid proof", async () => {
+  it("routes a first-time Google user without a valid proof to Complete signup", async () => {
     googleMembershipState = { kind: "first_time" }
     mockHasValidGoogleSignupProof.mockResolvedValue(false)
 
     const response = await GET(
-      new Request("https://console.superserve.ai/auth/callback?code=abc"),
+      new Request(
+        "https://console.superserve.ai/auth/callback?code=abc&next=https%3A%2F%2Fapp.superserve.ai%2Fdevice%2Fabc",
+      ),
     )
 
     expect(mockHasValidGoogleSignupProof).toHaveBeenCalled()
     expect(response.headers.get("location")).toContain(
-      "/auth/auth-code-error?reason=signup_verification_required",
+      "/auth/signup?complete_google=1&next=https%3A%2F%2Fapp.superserve.ai%2Fdevice%2Fabc",
     )
     expect(mockTrackEvent).toHaveBeenCalledWith(
       "auth_google_signup_bypass_blocked",

--- a/apps/console/src/app/(auth)/auth/callback/route.ts
+++ b/apps/console/src/app/(auth)/auth/callback/route.ts
@@ -142,10 +142,13 @@ export async function GET(request: Request) {
               console.warn("Google OAuth onboarding blocked", {
                 reason: "missing_or_invalid_proof",
               })
+              const recoveryUrl = new URL("/auth/signup", origin)
+              recoveryUrl.searchParams.set("complete_google", "1")
+              if (next !== "/") recoveryUrl.searchParams.set("next", next)
               return NextResponse.redirect(
                 buildRedirectUrl(
                   origin,
-                  "/auth/auth-code-error?reason=signup_verification_required",
+                  `${recoveryUrl.pathname}${recoveryUrl.search}`,
                 ),
               )
             }

--- a/apps/console/src/app/(auth)/auth/signup/page.test.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.test.tsx
@@ -83,7 +83,7 @@ vi.mock("./action", () => ({
   beginGoogleSignup: (token?: string) => mockBeginGoogleSignup(token),
 }))
 
-const mockSearchParams = new URLSearchParams()
+let mockSearchParams = new URLSearchParams()
 const mockRouterPush = vi.fn()
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
@@ -135,6 +135,7 @@ describe("SignUpPage", () => {
     mockEnsureFingerprintSignupEventId.mockResolvedValue(undefined)
     mockCapture.mockReset()
     mockRouterPush.mockReset()
+    mockSearchParams = new URLSearchParams()
     delete process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
     vi.resetModules()
     ;({ default: SignUpPage } = await import("./page"))
@@ -158,6 +159,23 @@ describe("SignUpPage", () => {
     expect(
       screen.getByRole("button", { name: /Continue with Google/ }),
     ).toBeInTheDocument()
+  })
+
+  it("renders Complete signup mode without the account-creation form", async () => {
+    mockSearchParams = new URLSearchParams("complete_google=1")
+    const { default: RecoverySignUpPage } = await import("./page")
+    render(<RecoverySignUpPage />)
+
+    expect(await screen.findByText("Complete signup")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /Complete signup with Google/ }),
+    ).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText("Full Name")).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText("Email")).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText("Password")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Sign Up" }),
+    ).not.toBeInTheDocument()
   })
 
   it("shows inline errors when submitting with empty fields", async () => {
@@ -395,6 +413,7 @@ describe("SignUpPage with reCAPTCHA configured", () => {
     mockBeginGoogleSignup.mockResolvedValue({ success: true })
     mockEnsureFingerprintSignupEventId.mockReset()
     mockEnsureFingerprintSignupEventId.mockResolvedValue(undefined)
+    mockSearchParams = new URLSearchParams()
     process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "test-site-key"
     vi.resetModules()
   })
@@ -490,6 +509,43 @@ describe("SignUpPage with reCAPTCHA configured", () => {
       expect(mockSignInWithOAuth).toHaveBeenCalledWith({
         provider: "google",
         options: { redirectTo: expect.stringContaining("/auth/callback") },
+      })
+    })
+  })
+
+  it("preserves next when completing signup with Google", async () => {
+    mockSearchParams = new URLSearchParams(
+      "complete_google=1&next=https%3A%2F%2Fapp.superserve.ai%2Fdevice%2Fabc",
+    )
+    const execute = vi.fn().mockResolvedValue("google-token")
+    mockBeginGoogleSignup.mockResolvedValue({ success: true })
+    ;(window as { grecaptcha?: unknown }).grecaptcha = {
+      enterprise: {
+        ready: (callback: () => void) => callback(),
+        execute,
+      },
+    }
+    const { default: ConfiguredSignUpPage } = await import("./page")
+    render(<ConfiguredSignUpPage />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Complete signup with Google/,
+      }),
+    )
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenCalledWith("test-site-key", {
+        action: "signup_google",
+      })
+      expect(mockBeginGoogleSignup).toHaveBeenCalledWith("google-token")
+      expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+        provider: "google",
+        options: {
+          redirectTo: expect.stringContaining(
+            "next=https%3A%2F%2Fapp.superserve.ai%2Fdevice%2Fabc",
+          ),
+        },
       })
     })
   })

--- a/apps/console/src/app/(auth)/auth/signup/page.tsx
+++ b/apps/console/src/app/(auth)/auth/signup/page.tsx
@@ -19,6 +19,8 @@ import { createBrowserClient } from "@/lib/supabase/client"
 import { beginGoogleSignup, signUpWithEmail } from "./action"
 
 const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+const TRUSTED_REDIRECT_PATTERN =
+  /^https:\/\/([a-z0-9-]+\.)?superserve\.ai(\/.*)?$/
 
 declare global {
   interface Window {
@@ -72,6 +74,13 @@ const getRecaptchaToken = async (
   }
 }
 
+function sanitizeNext(raw: string | null): string {
+  const next = raw ?? "/"
+  if (next.startsWith("/") && !next.startsWith("//")) return next
+  if (TRUSTED_REDIRECT_PATTERN.test(next)) return next
+  return "/"
+}
+
 function SignUpContent() {
   const [isLoading, setIsLoading] = useState(false)
   const [isGoogleLoading, setIsGoogleLoading] = useState(false)
@@ -86,8 +95,8 @@ function SignUpContent() {
   const posthog = usePostHog()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const rawNext = searchParams.get("next") || "/"
-  const nextUrl = rawNext.startsWith("/") ? rawNext : "/"
+  const nextUrl = sanitizeNext(searchParams.get("next"))
+  const isCompleteGoogleSignup = searchParams.get("complete_google") === "1"
 
   useEffect(() => {
     if (searchParams.get("error") === "link_expired") {
@@ -226,6 +235,31 @@ function SignUpContent() {
                 Sign in
               </Link>
             </p>
+          </>
+        ) : isCompleteGoogleSignup ? (
+          <>
+            <h1 className="mb-4 text-center text-sm font-medium text-foreground">
+              Complete signup
+            </h1>
+            <p className="mb-6 text-center text-xs leading-relaxed text-muted">
+              Google sign-in succeeded. Complete signup to finish verification
+              and provision your Superserve account.
+            </p>
+            {errors.form && (
+              <p className="mb-4 text-xs text-destructive">{errors.form}</p>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleGoogleSignIn}
+              disabled={isGoogleLoading || isLoading}
+              className="w-full gap-2 border-solid font-sans tracking-normal normal-case"
+            >
+              {isGoogleLoading ? <Spinner /> : <GoogleIcon />}
+              {isGoogleLoading
+                ? "Completing signup..."
+                : "Complete signup with Google"}
+            </Button>
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary

- route first-time Google users without a signup proof into a recoverable Complete signup flow
- reuse the existing CAPTCHA + beginGoogleSignup proof path instead of duplicating onboarding security logic
- keep established Google users on the normal CAPTCHA-free sign-in path

## Testing

- update auth callback regression coverage
- add signup-page recovery-mode coverage
