### PR TITLE
sdk(python): Retry self-clearing 409 on sandbox delete

### DIFF
--- a/packages/python-sdk/src/superserve/_http.py
+++ b/packages/python-sdk/src/superserve/_http.py
@@ -33,6 +33,7 @@ USER_AGENT = (
 
 # Retry tuning
 _MAX_ATTEMPTS = 3
+_CONFLICT_MAX_ATTEMPTS = 11
 _BASE_BACKOFF = 0.1
 _MAX_BACKOFF = 30.0
 _RETRY_STATUS_CODES = {429, 502, 503, 504}
@@ -151,6 +152,7 @@ def _do_request_with_retry(
     json_body: Any | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     client: httpx.Client | None = None,
+    retry_conflict: bool = False,
 ) -> httpx.Response:
     """Perform an HTTP request with retry for idempotent methods.
 
@@ -167,7 +169,8 @@ def _do_request_with_retry(
     last_exc: BaseException | None = None
 
     try:
-        for attempt in range(_MAX_ATTEMPTS):
+        max_attempts = _MAX_ATTEMPTS
+        for attempt in range(_CONFLICT_MAX_ATTEMPTS):
             try:
                 response = client.request(
                     method_upper,
@@ -184,7 +187,7 @@ def _do_request_with_retry(
                 last_exc = exc
                 if (
                     method_upper not in _IDEMPOTENT_METHODS
-                    or attempt == _MAX_ATTEMPTS - 1
+                    or attempt >= max_attempts - 1
                 ):
                     raise SandboxError(f"Network error: {exc}") from exc
                 time.sleep(_compute_backoff(attempt))
@@ -192,10 +195,14 @@ def _do_request_with_retry(
             except httpx.HTTPError as exc:
                 raise SandboxError(f"Network error: {exc}") from exc
 
-            if (
-                _should_retry_status(method_upper, response.status_code)
-                and attempt < _MAX_ATTEMPTS - 1
-            ):
+            if response.status_code == 409 and retry_conflict:
+                max_attempts = _CONFLICT_MAX_ATTEMPTS
+
+            is_retryable = _should_retry_status(
+                method_upper, response.status_code
+            ) or (response.status_code == 409 and retry_conflict)
+
+            if is_retryable and attempt < max_attempts - 1:
                 delay: float
                 if response.status_code == 429:
                     retry_after = _parse_retry_after(
@@ -232,6 +239,7 @@ def api_request(
     json_body: Any | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     client: httpx.Client | None = None,
+    retry_conflict: bool = False,
 ) -> Any:
     """Make a JSON API request. Returns parsed response body or None for 204."""
     merged = _default_headers(headers, content_type="application/json")
@@ -242,6 +250,7 @@ def api_request(
         json_body=json_body,
         timeout=timeout,
         client=client,
+        retry_conflict=retry_conflict,
     )
 
     if response.status_code == 204:
@@ -427,6 +436,7 @@ async def _async_do_request_with_retry(
     json_body: Any | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     client: httpx.AsyncClient | None = None,
+    retry_conflict: bool = False,
 ) -> httpx.Response:
     """Async variant of ``_do_request_with_retry``."""
     owned = client is None
@@ -438,7 +448,8 @@ async def _async_do_request_with_retry(
     last_exc: BaseException | None = None
 
     try:
-        for attempt in range(_MAX_ATTEMPTS):
+        max_attempts = _MAX_ATTEMPTS
+        for attempt in range(_CONFLICT_MAX_ATTEMPTS):
             try:
                 response = await client.request(
                     method_upper,
@@ -455,7 +466,7 @@ async def _async_do_request_with_retry(
                 last_exc = exc
                 if (
                     method_upper not in _IDEMPOTENT_METHODS
-                    or attempt == _MAX_ATTEMPTS - 1
+                    or attempt >= max_attempts - 1
                 ):
                     raise SandboxError(f"Network error: {exc}") from exc
                 await asyncio.sleep(_compute_backoff(attempt))
@@ -463,10 +474,14 @@ async def _async_do_request_with_retry(
             except httpx.HTTPError as exc:
                 raise SandboxError(f"Network error: {exc}") from exc
 
-            if (
-                _should_retry_status(method_upper, response.status_code)
-                and attempt < _MAX_ATTEMPTS - 1
-            ):
+            if response.status_code == 409 and retry_conflict:
+                max_attempts = _CONFLICT_MAX_ATTEMPTS
+
+            is_retryable = _should_retry_status(
+                method_upper, response.status_code
+            ) or (response.status_code == 409 and retry_conflict)
+
+            if is_retryable and attempt < max_attempts - 1:
                 delay: float
                 if response.status_code == 429:
                     retry_after = _parse_retry_after(
@@ -502,6 +517,7 @@ async def async_api_request(
     json_body: Any | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     client: httpx.AsyncClient | None = None,
+    retry_conflict: bool = False,
 ) -> Any:
     """Async variant of api_request."""
     merged = _default_headers(headers, content_type="application/json")
@@ -512,6 +528,7 @@ async def async_api_request(
         json_body=json_body,
         timeout=timeout,
         client=client,
+        retry_conflict=retry_conflict,
     )
 
     if response.status_code == 204:

--- a/packages/python-sdk/src/superserve/async_sandbox.py
+++ b/packages/python-sdk/src/superserve/async_sandbox.py
@@ -237,6 +237,7 @@ class AsyncSandbox:
                 "DELETE",
                 f"{config.base_url}/sandboxes/{sandbox_id}",
                 headers={"X-API-Key": config.api_key},
+                retry_conflict=True,
             )
         except NotFoundError:
             pass  # Already deleted
@@ -431,6 +432,7 @@ class AsyncSandbox:
                 f"{self._config.base_url}/sandboxes/{self.id}",
                 headers={"X-API-Key": self._config.api_key},
                 client=self._http_client,
+                retry_conflict=True,
             )
         except NotFoundError:
             pass  # Already deleted

--- a/packages/python-sdk/src/superserve/sandbox.py
+++ b/packages/python-sdk/src/superserve/sandbox.py
@@ -243,6 +243,7 @@ class Sandbox:
                 "DELETE",
                 f"{config.base_url}/sandboxes/{sandbox_id}",
                 headers={"X-API-Key": config.api_key},
+                retry_conflict=True,
             )
         except NotFoundError:
             pass  # Already deleted
@@ -433,6 +434,7 @@ class Sandbox:
                 f"{self._config.base_url}/sandboxes/{self.id}",
                 headers={"X-API-Key": self._config.api_key},
                 client=self._http_client,
+                retry_conflict=True,
             )
         except NotFoundError:
             pass  # Already deleted

--- a/packages/python-sdk/tests/test_http.py
+++ b/packages/python-sdk/tests/test_http.py
@@ -217,6 +217,40 @@ class TestRetriesSync:
             assert result is None
             assert route.call_count == 2
 
+    def test_delete_retries_on_409_with_retry_conflict(self, zero_sleep: None) -> None:
+        with respx.mock() as router:
+            route = router.delete("https://api.example.com/foo").mock(
+                side_effect=[
+                    httpx.Response(409, json={"error": {"code": "conflict"}}),
+                    httpx.Response(409, json={"error": {"code": "conflict"}}),
+                    httpx.Response(204),
+                ]
+            )
+            result = api_request(
+                "DELETE",
+                "https://api.example.com/foo",
+                headers={"X-API-Key": "k"},
+                retry_conflict=True,
+            )
+            assert result is None
+            assert route.call_count == 3
+
+    def test_delete_409_without_retry_conflict_fails_fast(self, zero_sleep: None) -> None:
+        from superserve.errors import ConflictError
+
+        with respx.mock() as router:
+            route = router.delete("https://api.example.com/foo").mock(
+                return_value=httpx.Response(409, json={"error": {"code": "conflict"}})
+            )
+            with pytest.raises(ConflictError):
+                api_request(
+                    "DELETE",
+                    "https://api.example.com/foo",
+                    headers={"X-API-Key": "k"},
+                    retry_conflict=False,
+                )
+            assert route.call_count == 1
+
     def test_connect_error_retries_on_get(self, zero_sleep: None) -> None:
         with respx.mock() as router:
             route = router.get("https://api.example.com/foo").mock(
@@ -358,6 +392,23 @@ class TestAsyncApiRequest:
                 "GET", "https://api.example.com/foo", headers={"X-API-Key": "k"}
             )
             assert result == {"ok": True}
+            assert route.call_count == 2
+
+    async def test_delete_retries_on_409_with_retry_conflict(self, zero_sleep: None) -> None:
+        with respx.mock() as router:
+            route = router.delete("https://api.example.com/foo").mock(
+                side_effect=[
+                    httpx.Response(409, json={"error": {"code": "conflict"}}),
+                    httpx.Response(204),
+                ]
+            )
+            result = await async_api_request(
+                "DELETE",
+                "https://api.example.com/foo",
+                headers={"X-API-Key": "k"},
+                retry_conflict=True,
+            )
+            assert result is None
             assert route.call_count == 2
 
     async def test_timeout_raises_sandbox_timeout(self) -> None:


### PR DESCRIPTION
Follow-up to #308: mirrors the same retry logic in the Python SDK.

When a sandbox is deleted while mid-transition (e.g., resuming from pause), the control plane returns a `409 Conflict`. Like the TypeScript SDK, this PR introduces a `retry_conflict` flag to the internal HTTP layer that extends the backoff budget (to 11 attempts) specifically for this self-clearing state.

`Sandbox.kill` and `Sandbox.kill_by_id` (and their async variants) now pass `retry_conflict=True`, allowing them to transparently wait out the transition instead of failing fast and leaving orphaned sandboxes.

- **Sync & Async HTTP Layers:** Extended to support dynamic `max_attempts` growth on 409s.
- **API Surface:** Unchanged. `retry_conflict` remains an internal kwarg.
- **Tests Added:** Unit tests verify that a `409` correctly retries up to the conflict budget, while normal requests fail fast on terminal `409`s.

This brings the Python SDK into complete parity with the TS SDK's delete behavior.