### PR TITLE
fix(console): Stop exposing raw Next.js server errors in ErrorStates

### DIFF
--- a/apps/console/src/app/(dashboard)/admin/teams/[team_id]/team-sandboxes-client.tsx
+++ b/apps/console/src/app/(dashboard)/admin/teams/[team_id]/team-sandboxes-client.tsx
@@ -103,7 +103,7 @@ export function TeamSandboxesClient({
       {isPending ? (
         <TableSkeleton columns={4} />
       ) : error ? (
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       ) : sandboxes.length === 0 ? (
         <EmptyState
           icon={CubeIcon}

--- a/apps/console/src/app/(dashboard)/api-keys/error.tsx
+++ b/apps/console/src/app/(dashboard)/api-keys/error.tsx
@@ -11,10 +11,7 @@ export default function ApiKeysError({
 }) {
   return (
     <div className="flex h-full items-center justify-center">
-      <ErrorState
-        message={error.message || "Something went wrong"}
-        onRetry={reset}
-      />
+      <ErrorState onRetry={reset} />
     </div>
   )
 }

--- a/apps/console/src/app/(dashboard)/api-keys/page.tsx
+++ b/apps/console/src/app/(dashboard)/api-keys/page.tsx
@@ -111,7 +111,7 @@ function ApiKeysPageContent() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="API Keys" />
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/app/(dashboard)/audit-logs/page.tsx
+++ b/apps/console/src/app/(dashboard)/audit-logs/page.tsx
@@ -169,7 +169,7 @@ function AuditLogsPageContent() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="Audit Logs" />
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/app/(dashboard)/error.tsx
+++ b/apps/console/src/app/(dashboard)/error.tsx
@@ -11,10 +11,7 @@ export default function DashboardError({
 }) {
   return (
     <div className="flex h-full items-center justify-center">
-      <ErrorState
-        message={error.message || "Something went wrong"}
-        onRetry={reset}
-      />
+      <ErrorState onRetry={reset} />
     </div>
   )
 }

--- a/apps/console/src/app/(dashboard)/sandboxes/error.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/error.tsx
@@ -11,10 +11,7 @@ export default function SandboxesError({
 }) {
   return (
     <div className="flex h-full items-center justify-center">
-      <ErrorState
-        message={error.message || "Something went wrong"}
-        onRetry={reset}
-      />
+      <ErrorState onRetry={reset} />
     </div>
   )
 }

--- a/apps/console/src/app/(dashboard)/sandboxes/page.tsx
+++ b/apps/console/src/app/(dashboard)/sandboxes/page.tsx
@@ -179,7 +179,7 @@ function SandboxesPageContent() {
       {isPending ? (
         <TableSkeleton columns={6} tabs={3} />
       ) : error ? (
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       ) : isEmpty ? (
         <EmptyState
           icon={CubeIcon}

--- a/apps/console/src/app/(dashboard)/secrets/page.tsx
+++ b/apps/console/src/app/(dashboard)/secrets/page.tsx
@@ -67,7 +67,7 @@ function SecretsPageContent() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="Secrets">{newButton}</PageHeader>
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/app/(dashboard)/snapshots/page.tsx
+++ b/apps/console/src/app/(dashboard)/snapshots/page.tsx
@@ -67,7 +67,7 @@ export default function SnapshotsPage() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="Snapshots" />
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/app/(dashboard)/templates/templates-page-client.tsx
+++ b/apps/console/src/app/(dashboard)/templates/templates-page-client.tsx
@@ -113,7 +113,7 @@ function TemplatesPageContent() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="Templates">{newButton}</PageHeader>
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/app/(dashboard)/user-management/user-management-client.tsx
+++ b/apps/console/src/app/(dashboard)/user-management/user-management-client.tsx
@@ -538,7 +538,7 @@ export function UserManagementClient() {
     return (
       <div className="flex h-full flex-col">
         <PageHeader title="User Management" />
-        <ErrorState message={error.message} onRetry={() => refetch()} />
+        <ErrorState onRetry={() => refetch()} />
       </div>
     )
   }

--- a/apps/console/src/components/sandboxes/activity-section.tsx
+++ b/apps/console/src/components/sandboxes/activity-section.tsx
@@ -54,7 +54,6 @@ export function ActivitySection({
         <div className="border-b border-border">
           <ErrorState
             title="Unable to load activity"
-            message={error.message}
             onRetry={onRetry}
           />
         </div>


### PR DESCRIPTION
Resolves #307 

Next.js replaces Server Action errors with a generic framework message in production: *"An error occurred in the Server Components render..."*. Because the console passed `error.message` directly into `<ErrorState>` across several pages, this long and confusing framework message was exposed to users whenever an error occurred.

This PR audits the console and removes the `message={error.message}` prop from all `ErrorState` components. By omitting the prop, the UI now correctly falls back to the clean, stable default message (`"An error occurred while loading data. Please try again."`), dramatically improving the production user experience for failed data loads. 

**Files Updated:**
- `apps/console/src/components/sandboxes/activity-section.tsx`
- `apps/console/src/app/(dashboard)/api-keys/page.tsx`
- `apps/console/src/app/(dashboard)/audit-logs/page.tsx`
- `apps/console/src/app/(dashboard)/secrets/page.tsx`
- `apps/console/src/app/(dashboard)/user-management/user-management-client.tsx`
- `apps/console/src/app/(dashboard)/templates/templates-page-client.tsx`
- `apps/console/src/app/(dashboard)/snapshots/page.tsx`
- `apps/console/src/app/(dashboard)/sandboxes/page.tsx`
- `apps/console/src/app/(dashboard)/admin/teams/[team_id]/team-sandboxes-client.tsx`
- `error.tsx` handlers for `sandboxes`, `api-keys`, and global `(dashboard)`
