### PR TITLE
fix(mcp): prevent dev watcher from deleting http.js and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,17 @@ Thank you for your interest in contributing to Superserve! We welcome contributi
 
 ```
 apps/console/              # Sandbox dashboard (Next.js 16, App Router)
+apps/mcp/                  # MCP host API endpoint
 apps/ui-docs/              # UI component documentation (Vite)
+docs/                      # Mintlify documentation site
 packages/cli/              # TypeScript CLI (@superserve/cli)
+packages/mcp/              # MCP server implementation (@superserve/mcp)
 packages/python-sdk/       # Python SDK (superserve on PyPI)
 packages/sdk/              # TypeScript SDK (@superserve/sdk)
 packages/ui/               # Shared UI components (@superserve/ui)
 packages/typescript-config/ # Shared tsconfig presets
 packages/tailwind-config/  # Shared Tailwind config
+tests/                     # End-to-end SDK tests
 ```
 
 ## Common Commands

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "build": "tsup && tsup --config tsup.http.config.ts",
-    "dev": "tsup --watch",
+    "dev": "tsup --watch & tsup --watch --config tsup.http.config.ts",
     "start:http": "node dist/httpServer.js",
     "lint": "bunx oxlint",
     "format": "bunx oxfmt --write",

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "tsup"
 // `tsup.http.config.ts` (chained after this in the `build` script) so that only
 // these executables get a shebang — a leading `#!` breaks some bundlers when the
 // `http` file is imported by the console / edge runtimes.
-export default defineConfig({
+export default defineConfig((options) => ({
   entry: { index: "src/index.ts", httpServer: "src/httpServer.ts" },
   format: ["esm"],
   target: "node18",
@@ -13,7 +13,7 @@ export default defineConfig({
   // surface (multi-minute), and these are executables.
   dts: false,
   sourcemap: true,
-  clean: true,
+  clean: !options.watch,
   // Shebang so the published bins are directly executable via npx.
   banner: { js: "#!/usr/bin/env node" },
-})
+}))

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,7 @@
       "outputs": ["dist/**", ".next/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
### Summary
This PR fixes the issue where `bun run dev` deletes `dist/http.js` and causes `@superserve/mcp/http` import failures in the Next.js app. It also resolves the missing `dependsOn` configuration for the dev task.

Fixes #329

### Changes Made
1. **`turbo.json`**: Added `"dependsOn": ["^build"]` to the `"dev"` task so dependencies are built before the dev server starts (preventing empty `dist/` folders on fresh clones).
2. **`packages/mcp/package.json`**: Updated the `"dev"` script to run both tsup watchers concurrently (`tsup --watch & tsup --watch --config tsup.http.config.ts`).
3. **`packages/mcp/tsup.config.ts`**: Converted `defineConfig` to a function and set `clean: !options.watch`. This prevents the watcher from wiping the directory and deleting `http.js` during concurrent dev builds.
4. **`CONTRIBUTING.md`**: As requested in the issue, added the missing directories (`apps/mcp`, `packages/mcp`, `tests/`, and `docs/`) to the Repo Structure section.

### Testing
- Ran `bun run build` followed by `bun run dev` locally. Verified that `http.js` is no longer deleted by the watcher.
- Successfully verified that all checks pass (`bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`).